### PR TITLE
Feat: Update all fn use ThreadRng in ChaserPage by allow apply custom rng for thread safe or sub thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dunce = "1"
 bytes = { version = "1", features = ["serde"], optional = true }
 reqwest = { version = "0.12", default-features = false }
 dashmap = "6"
-rand = "0.8"
+rand = "0.9"
 anyhow = "1"
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ futures = "0.3"
 ```rust
 use chaser_oxide::{Browser, BrowserConfig, ChaserPage, ChaserProfile};
 use futures::StreamExt;
+use rand::Rng;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -60,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
     // 3. Create page and wrap in ChaserPage
     let page = browser.new_page("about:blank").await?;
     let chaser = ChaserPage::new(page);
+    let mut rng = rand::thread_rng();
 
     // 4. Apply profile (sets UA + injects stealth scripts) - BEFORE navigation
     chaser.apply_profile(&profile).await?;
@@ -71,9 +73,9 @@ async fn main() -> anyhow::Result<()> {
     let title: Option<String> = chaser.evaluate("document.title").await?;
 
     // 7. Use human-like interaction methods
-    chaser.move_mouse_human(400.0, 300.0).await?;
-    chaser.click_human(500.0, 400.0).await?;
-    chaser.type_text("Search query").await?;
+    chaser.move_mouse_human(400.0, 300.0, &mut rng).await?;
+    chaser.click_human(500.0, 400.0, &mut rng).await?;
+    chaser.type_text("Search query", &mut rng).await?;
 
     Ok(())
 }
@@ -137,13 +139,13 @@ impl ChaserPage {
     async fn evaluate(&self, script: &str) -> Result<Option<Value>>;  // Stealth!
     
     // Human-like Mouse Movement (Bezier curves)
-    async fn move_mouse_human(&self, x: f64, y: f64) -> Result<()>;
-    async fn click_human(&self, x: f64, y: f64) -> Result<()>;
-    async fn scroll_human(&self, delta_y: i32) -> Result<()>;
+    async fn move_mouse_human(&self, x: f64, y: f64, rng: &mut impl Rng) -> Result<()>;
+    async fn click_human(&self, x: f64, y: f64, rng: &mut impl Rng) -> Result<()>;
+    async fn scroll_human(&self, delta_y: i32, rng: &mut impl Rng) -> Result<()>;
     
     // Human-like Typing
-    async fn type_text(&self, text: &str) -> Result<()>;
-    async fn type_text_with_typos(&self, text: &str) -> Result<()>;
+    async fn type_text(&self, text: &str, rng: &mut impl Rng) -> Result<()>;
+    async fn type_text_with_typos(&self, text: &str, rng: &mut impl Rng) -> Result<()>;
     
     // Request Interception
     async fn enable_request_interception(&self, pattern: &str, resource_type: Option<ResourceType>) -> Result<()>;

--- a/examples/add-init-script.rs
+++ b/examples/add-init-script.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/block-navigation.rs
+++ b/examples/block-navigation.rs
@@ -4,14 +4,13 @@ use std::time::Duration;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
+use chaser_oxide::{Browser, BrowserConfig, Page};
+use chaser_oxide::cdp::browser_protocol::fetch::{
     self, ContinueRequestParams, EventRequestPaused, FailRequestParams, FulfillRequestParams,
 };
-use chromiumoxide::cdp::browser_protocol::network::{
+use chaser_oxide::cdp::browser_protocol::network::{
     self, ErrorReason, EventRequestWillBeSent, ResourceType,
 };
-use chromiumoxide::Page;
 use futures::{select, StreamExt};
 use tokio::time::sleep;
 

--- a/examples/console-logs.rs
+++ b/examples/console-logs.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use chromiumoxide::{cdp::js_protocol::runtime::EventConsoleApiCalled, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig, cdp::js_protocol::runtime::EventConsoleApiCalled};
 use futures::StreamExt;
 
 const TARGET: &str = "https://www.microsoft.com/";
@@ -12,7 +12,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let (mut browser, mut handler) =
-        chromiumoxide::Browser::launch(BrowserConfig::builder().with_head().build().unwrap())
+        Browser::launch(BrowserConfig::builder().with_head().build().unwrap())
             .await
             .expect("failed to launch browser");
 

--- a/examples/evaluate-on-new-document.rs
+++ b/examples/evaluate-on-new-document.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/evaluate.rs
+++ b/examples/evaluate.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
     CallArgument, CallFunctionOnParams, EvaluateParams,
 };

--- a/examples/fetcher-async-std.rs
+++ b/examples/fetcher-async-std.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
+use chaser_oxide::{Browser, BrowserConfig, BrowserFetcher, BrowserFetcherOptions};
 use futures::StreamExt;
 
 #[async_std::main]

--- a/examples/fetcher.rs
+++ b/examples/fetcher.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
+use chaser_oxide::{Browser, BrowserConfig, BrowserFetcher, BrowserFetcherOptions};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/httpfuture.rs
+++ b/examples/httpfuture.rs
@@ -1,5 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::page::NavigateParams;
+use chaser_oxide::{Browser, BrowserConfig, cdp::browser_protocol::page::NavigateParams};
 use futures::StreamExt;
 use futures::TryFutureExt;
 

--- a/examples/iframe-workaround.rs
+++ b/examples/iframe-workaround.rs
@@ -2,7 +2,7 @@
 // a problem with the iframe workaround is that it will always fail to load the page
 // and goto will cause a timeout.
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/incognito.rs
+++ b/examples/incognito.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/interception.rs
+++ b/examples/interception.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
+use chaser_oxide::{Browser, BrowserConfig};
+use chaser_oxide::cdp::browser_protocol::fetch::{
     ContinueRequestParams, EventRequestPaused, FulfillRequestParams,
 };
 use futures::StreamExt;

--- a/examples/js-binding-listener.rs
+++ b/examples/js-binding-listener.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{AddBindingParams, EventBindingCalled};
 use futures::StreamExt;
 use tokio::sync::Mutex;

--- a/examples/pdf.rs
+++ b/examples/pdf.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::browser_protocol::page::PrintToPdfParams;
 use futures::StreamExt;
 

--- a/examples/profile_demo.rs
+++ b/examples/profile_demo.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     let chaser = ChaserPage::new(page);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Demonstrate click_human (combines bezier + click)
     println!("\nTesting click_human()...");

--- a/examples/profile_demo.rs
+++ b/examples/profile_demo.rs
@@ -68,14 +68,15 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(3)).await;
 
     let chaser = ChaserPage::new(page);
+    let mut rng = rand::thread_rng();
 
     // Demonstrate click_human (combines bezier + click)
     println!("\nTesting click_human()...");
-    chaser.click_human(400.0, 300.0).await?;
+    chaser.click_human(400.0, 300.0, &mut rng).await?;
 
     // Demonstrate type_text_with_typos
     println!("Testing type_text_with_typos()...");
-    // chaser.type_text_with_typos("Hello world").await?;
+    // chaser.type_text_with_typos("Hello world", &mut rng).await?;
 
     tokio::time::sleep(Duration::from_secs(3)).await;
 

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,5 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::page::ScreenshotParams;
+use chaser_oxide::{Browser, BrowserConfig, page::ScreenshotParams};
 use chromiumoxide_cdp::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use futures::StreamExt;
 

--- a/examples/simple-google.rs
+++ b/examples/simple-google.rs
@@ -1,14 +1,13 @@
 use std::time::Duration;
 
-use chromiumoxide::browser::BrowserConfigBuilder;
-use chromiumoxide::Browser;
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
     let (browser, mut handler) = Browser::launch(
-        BrowserConfigBuilder::default()
+        BrowserConfig::builder()
             .request_timeout(Duration::from_secs(5))
             .build()
             .unwrap(),

--- a/examples/stealth_bot.rs
+++ b/examples/stealth_bot.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
 
     // Upgrade to ChaserPage
     let chaser = ChaserPage::new(page);
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Human-like mouse movement
     println!("Simulating human mouse movement...");

--- a/examples/stealth_bot.rs
+++ b/examples/stealth_bot.rs
@@ -37,10 +37,11 @@ async fn main() -> Result<()> {
 
     // Upgrade to ChaserPage
     let chaser = ChaserPage::new(page);
+    let mut rng = rand::thread_rng();
 
     // Human-like mouse movement
     println!("Simulating human mouse movement...");
-    chaser.move_mouse_human(500.0, 300.0).await?;
+    chaser.move_mouse_human(500.0, 300.0, &mut rng).await?;
 
     // Test stealth execution
     println!("\nReading values from the PAGE (main world sees spoofed values):");
@@ -54,7 +55,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     chaser
-        .inner()
+        .raw_page()
         .save_screenshot(
             chaser_oxide::page::ScreenshotParams::builder().build(),
             "stealth_test.png",

--- a/examples/storage-cookie.rs
+++ b/examples/storage-cookie.rs
@@ -1,6 +1,4 @@
-use chromiumoxide::browser::Browser;
-use chromiumoxide::browser::BrowserConfig;
-use chromiumoxide::cdp::browser_protocol::network::CookieParam;
+use chaser_oxide::{Browser, BrowserConfig, cdp::browser_protocol::network::CookieParam};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/wiki-async-std.rs
+++ b/examples/wiki-async-std.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[async_std::main]

--- a/examples/wiki.rs
+++ b/examples/wiki.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/src/chaser.rs
+++ b/src/chaser.rs
@@ -338,8 +338,8 @@ impl ChaserPage {
         let end = Point { x, y };
 
         // Target Selection Jitter: don't land exactly on the pixel
-        let jitter_x = rng.gen_range(-2.0..2.0);
-        let jitter_y = rng.gen_range(-2.0..2.0);
+        let jitter_x = rng.random_range(-2.0..2.0);
+        let jitter_y = rng.random_range(-2.0..2.0);
         let target_with_jitter = Point {
             x: end.x + jitter_x,
             y: end.y + jitter_y,
@@ -357,7 +357,7 @@ impl ChaserPage {
                 .map_err(|e| anyhow!("{}", e))?;
             *self.mouse_pos.lock().unwrap() = point;
             // Tiny delay to simulate physical movement
-            tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(5..15))).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(5..15))).await;
         }
 
         Ok(())
@@ -384,13 +384,13 @@ impl ChaserPage {
         self.move_mouse_human(x, y, rng).await?;
 
         // Small pause before clicking (humans don't click instantly after arriving)
-        tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(50..150))).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(50..150))).await;
 
         // Click
         self.click().await?;
 
         // Small pause after clicking
-        tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(30..80))).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(30..80))).await;
 
         Ok(())
     }
@@ -443,11 +443,11 @@ impl ChaserPage {
                 .map_err(|e| anyhow!("{}", e))?;
 
             // Random delay between keystrokes
-            let delay = rng.gen_range(min_delay_ms..max_delay_ms);
+            let delay = rng.random_range(min_delay_ms..max_delay_ms);
 
             // 5% chance of a longer "thinking" pause
-            let actual_delay = if rng.gen_bool(0.05) {
-                rng.gen_range(200..400)
+            let actual_delay = if rng.random_bool(0.05) {
+                rng.random_range(200..400)
             } else {
                 delay
             };
@@ -503,13 +503,13 @@ impl ChaserPage {
 
     /// Press Enter key with a small random delay before pressing.
     pub async fn press_enter(&self, rng: &mut impl Rng) -> Result<()> {
-        tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(100..300))).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(100..300))).await;
         self.press_key("Enter").await
     }
 
     /// Press Tab key to move to next field.
     pub async fn press_tab(&self, rng: &mut impl Rng) -> Result<()> {
-        tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(50..150))).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(50..150))).await;
         self.press_key("Tab").await
     }
 
@@ -545,7 +545,7 @@ impl ChaserPage {
             };
 
             let base_step = remaining / (steps - i) as i32;
-            let jitter = rng.gen_range(-10..10);
+            let jitter = rng.random_range(-10..10);
             let step = ((base_step as f64 * ease) as i32 + jitter).clamp(-200, 200);
 
             if step == 0 {
@@ -569,7 +569,7 @@ impl ChaserPage {
             remaining -= step;
 
             // Variable delay between scroll events (16-50ms for 60-20 FPS feel)
-            tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(16..50))).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(16..50))).await;
         }
 
         Ok(())
@@ -584,27 +584,27 @@ impl ChaserPage {
 
         for c in text.chars() {
             // 3% chance of typo
-            if rng.gen_bool(0.03) && c.is_alphabetic() {
+            if rng.random_bool(0.03) && c.is_alphabetic() {
                 // Type wrong character
-                let typo = typo_chars[rng.gen_range(0..typo_chars.len())];
+                let typo = typo_chars[rng.random_range(0..typo_chars.len())];
                 self.type_single_char(typo).await?;
 
                 // Brief pause to "notice" the mistake
-                tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(100..300)))
+                tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(100..300)))
                     .await;
 
                 // Backspace to correct
                 self.press_key("Backspace").await?;
-                tokio::time::sleep(tokio::time::Duration::from_millis(rng.gen_range(30..80))).await;
+                tokio::time::sleep(tokio::time::Duration::from_millis(rng.random_range(30..80))).await;
             }
 
             // Type the correct character
             self.type_single_char(c).await?;
 
             // Random delay
-            let delay = rng.gen_range(50..150);
-            let actual_delay = if rng.gen_bool(0.05) {
-                rng.gen_range(200..400) // thinking pause
+            let delay = rng.random_range(50..150);
+            let actual_delay = if rng.random_bool(0.05) {
+                rng.random_range(200..400) // thinking pause
             } else {
                 delay
             };
@@ -656,18 +656,18 @@ impl BezierPath {
 
         // First control point (25% along the path with random offset)
         let p1 = Point {
-            x: start.x + (end.x - start.x) * 0.25 + rng.gen_range(-offset_range..offset_range),
-            y: start.y + (end.y - start.y) * 0.25 + rng.gen_range(-offset_range..offset_range),
+            x: start.x + (end.x - start.x) * 0.25 + rng.random_range(-offset_range..offset_range),
+            y: start.y + (end.y - start.y) * 0.25 + rng.random_range(-offset_range..offset_range),
         };
 
         // Second control point (75% along the path with random offset)
         // 20% chance of overshoot
         let mut p2 = Point {
-            x: start.x + (end.x - start.x) * 0.75 + rng.gen_range(-offset_range..offset_range),
-            y: start.y + (end.y - start.y) * 0.75 + rng.gen_range(-offset_range..offset_range),
+            x: start.x + (end.x - start.x) * 0.75 + rng.random_range(-offset_range..offset_range),
+            y: start.y + (end.y - start.y) * 0.75 + rng.random_range(-offset_range..offset_range),
         };
 
-        if rng.gen_bool(0.20) {
+        if rng.random_bool(0.20) {
             let overshoot_amt = dist * 0.05;
             p2.x += if end.x > start.x {
                 overshoot_amt

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 use std::panic;
 
-use chromiumoxide::{Browser, BrowserConfig};
+use chaser_oxide::{Browser, BrowserConfig};
 use futures::{FutureExt, StreamExt};
 
 mod basic;


### PR DESCRIPTION
### Issue 
Fix all fn use ThreadRng by allow apply custom rng for thread safe or sub thread
- ThreadRng is not Send - it uses thread-local storage
- StdRng and SmallRng are Send - they can be safely used across .await points

### Description of changes

- Update rand
- Update examples import
- Update add rng parameter to `move_mouse_human`, `click_human`, `type_text`, `press_enter`, `press_tab`, `scroll_human`, `type_text_with_typos`

### Checklist

- [ ] Added change to the changelog
- [ ] Created unit tests for my feature (if needed)
- [ ] Created a least one integration test
