### PR TITLE
fix: update examples to use chaser_oxide crate name + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+chaser-oxide is a Rust-based fork of `chromiumoxide` specialized for hardened browser automation. It provides protocol-level stealth modifications to the Chrome DevTools Protocol (CDP) client to reduce the detection footprint of automated browser sessions.
+
+## Build & Test Commands
+
+```bash
+# Build the project
+cargo build
+
+# Run unit tests (library only)
+cargo test --lib
+
+# Run integration tests (requires Chrome/Chromium installed)
+RUST_TEST_THREADS=1 cargo test --test '*'
+
+# Run a specific test
+cargo test --lib test_name
+
+# Format code
+cargo fmt
+
+# Run lints (CI requires no warnings)
+cargo clippy --all -- -D warnings
+
+# Check examples compile
+cargo check --examples --features tokio-runtime,bytes
+
+# Run an example
+cargo run --example stealth_bot
+cargo run --example profile_demo
+```
+
+## Workspace Structure
+
+This is a Cargo workspace with multiple crates:
+
+- **`chaser-oxide`** (root) - Main library with stealth automation API
+- **`chromiumoxide_cdp`** - Generated CDP protocol definitions (~60K lines, generated at build time)
+- **`chromiumoxide_pdl`** - PDL (Protocol Definition Language) parser for generating CDP bindings
+- **`chromiumoxide_types`** - Shared types across crates
+- **`chromiumoxide_fetcher`** - Optional browser binary fetcher
+
+## Architecture
+
+### Core API Layers
+
+1. **`ChaserPage`** (`src/chaser.rs`) - High-level stealth wrapper around `Page`
+   - Stealth JS execution via `Page.createIsolatedWorld` (avoids `Runtime.enable` detection)
+   - Human-like input simulation (Bezier mouse curves, variable typing delays)
+   - Request interception via Fetch domain
+   - Access underlying `Page` via `raw_page()`
+
+2. **`ChaserProfile`** (`src/profiles.rs`) - Browser fingerprint profiles
+   - Builder pattern for customizing OS, GPU, hardware specs
+   - Generates User-Agent and bootstrap JS script for spoofing
+   - Presets: `windows()`, `linux()`, `macos_arm()`, `macos_intel()`
+
+3. **`Page`** (`src/page.rs`) - Base CDP page abstraction (from chromiumoxide)
+   - `enable_stealth_mode()` - Quick stealth setup with sensible defaults
+   - Standard CDP operations (navigate, screenshot, cookies, etc.)
+
+4. **`StealthProfile` trait** (`src/stealth.rs`) - Legacy trait-based profile system
+   - Pre-built profiles: `WindowsNvidiaProfile`, `MacOSProfile`, `LinuxProfile`
+
+### Key Design Decisions
+
+- **Stealth execution**: `ChaserPage.evaluate()` uses `Page.createIsolatedWorld` to run JS without triggering `Runtime.enable`, which anti-bots detect. The regular `Page.evaluate()` triggers detection.
+
+- **Profile consistency**: All fingerprint values (User-Agent, platform, WebGL, hardware) must be internally consistent. A Windows UA with MacOS platform is immediately flagged.
+
+- **Properties on prototypes**: Stealth overrides are set on `Navigator.prototype` rather than `navigator` instance to avoid `getOwnPropertyNames` detection.
+
+## Runtime Features
+
+Default features use tokio. For async-std:
+```bash
+cargo build --features async-std-runtime --no-default-features
+```
+
+## Usage Pattern
+
+```rust
+// 1. Create profile
+let profile = ChaserProfile::windows().chrome_version(130).build();
+
+// 2. Launch browser
+let (browser, mut handler) = Browser::launch(BrowserConfig::builder().build()?).await?;
+tokio::spawn(async move { while let Some(_) = handler.next().await {} });
+
+// 3. Create page and wrap
+let page = browser.new_page("about:blank").await?;
+let chaser = ChaserPage::new(page);
+
+// 4. Apply profile BEFORE navigation
+chaser.apply_profile(&profile).await?;
+
+// 5. Navigate and interact
+chaser.goto("https://example.com").await?;
+let title: Option<Value> = chaser.evaluate("document.title").await?;
+```
+
+## Minimum Supported Rust Version
+
+MSRV is 1.75 (checked in CI).

--- a/examples/add-init-script.rs
+++ b/examples/add-init-script.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/block-navigation.rs
+++ b/examples/block-navigation.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::cdp::browser_protocol::fetch::{
     self, ContinueRequestParams, EventRequestPaused, FailRequestParams, FulfillRequestParams,
 };
-use chromiumoxide::cdp::browser_protocol::network::{
+use chaser_oxide::cdp::browser_protocol::network::{
     self, ErrorReason, EventRequestWillBeSent, ResourceType,
 };
-use chromiumoxide::Page;
+use chaser_oxide::Page;
 use futures::{select, StreamExt};
 use tokio::time::sleep;
 

--- a/examples/console-logs.rs
+++ b/examples/console-logs.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use chromiumoxide::{cdp::js_protocol::runtime::EventConsoleApiCalled, BrowserConfig};
+use chaser_oxide::{cdp::js_protocol::runtime::EventConsoleApiCalled, BrowserConfig};
 use futures::StreamExt;
 
 const TARGET: &str = "https://www.microsoft.com/";
@@ -12,7 +12,7 @@ async fn main() {
     tracing_subscriber::fmt::init();
 
     let (mut browser, mut handler) =
-        chromiumoxide::Browser::launch(BrowserConfig::builder().with_head().build().unwrap())
+        chaser_oxide::Browser::launch(BrowserConfig::builder().with_head().build().unwrap())
             .await
             .expect("failed to launch browser");
 

--- a/examples/evaluate-on-new-document.rs
+++ b/examples/evaluate-on-new-document.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/evaluate.rs
+++ b/examples/evaluate.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{
     CallArgument, CallFunctionOnParams, EvaluateParams,
 };

--- a/examples/fetcher-async-std.rs
+++ b/examples/fetcher-async-std.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
 use futures::StreamExt;
 
 #[async_std::main]

--- a/examples/fetcher.rs
+++ b/examples/fetcher.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::fetcher::{BrowserFetcher, BrowserFetcherOptions};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/httpfuture.rs
+++ b/examples/httpfuture.rs
@@ -1,5 +1,5 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::page::NavigateParams;
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::cdp::browser_protocol::page::NavigateParams;
 use futures::StreamExt;
 use futures::TryFutureExt;
 

--- a/examples/iframe-workaround.rs
+++ b/examples/iframe-workaround.rs
@@ -2,7 +2,7 @@
 // a problem with the iframe workaround is that it will always fail to load the page
 // and goto will cause a timeout.
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/incognito.rs
+++ b/examples/incognito.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/interception.rs
+++ b/examples/interception.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::cdp::browser_protocol::fetch::{
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::cdp::browser_protocol::fetch::{
     ContinueRequestParams, EventRequestPaused, FulfillRequestParams,
 };
 use futures::StreamExt;

--- a/examples/js-binding-listener.rs
+++ b/examples/js-binding-listener.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::js_protocol::runtime::{AddBindingParams, EventBindingCalled};
 use futures::StreamExt;
 use tokio::sync::Mutex;

--- a/examples/pdf.rs
+++ b/examples/pdf.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use chromiumoxide_cdp::cdp::browser_protocol::page::PrintToPdfParams;
 use futures::StreamExt;
 

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,5 +1,5 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
-use chromiumoxide::page::ScreenshotParams;
+use chaser_oxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::page::ScreenshotParams;
 use chromiumoxide_cdp::cdp::browser_protocol::page::CaptureScreenshotFormat;
 use futures::StreamExt;
 

--- a/examples/simple-google.rs
+++ b/examples/simple-google.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use chromiumoxide::browser::BrowserConfigBuilder;
-use chromiumoxide::Browser;
+use chaser_oxide::browser::BrowserConfigBuilder;
+use chaser_oxide::Browser;
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/stealth_bot.rs
+++ b/examples/stealth_bot.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     chaser
-        .inner()
+        .raw_page()
         .save_screenshot(
             chaser_oxide::page::ScreenshotParams::builder().build(),
             "stealth_test.png",

--- a/examples/storage-cookie.rs
+++ b/examples/storage-cookie.rs
@@ -1,6 +1,6 @@
-use chromiumoxide::browser::Browser;
-use chromiumoxide::browser::BrowserConfig;
-use chromiumoxide::cdp::browser_protocol::network::CookieParam;
+use chaser_oxide::browser::Browser;
+use chaser_oxide::browser::BrowserConfig;
+use chaser_oxide::cdp::browser_protocol::network::CookieParam;
 use futures::StreamExt;
 
 #[tokio::main]

--- a/examples/wiki-async-std.rs
+++ b/examples/wiki-async-std.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[async_std::main]

--- a/examples/wiki.rs
+++ b/examples/wiki.rs
@@ -1,4 +1,4 @@
-use chromiumoxide::browser::{Browser, BrowserConfig};
+use chaser_oxide::browser::{Browser, BrowserConfig};
 use futures::StreamExt;
 
 #[tokio::main]


### PR DESCRIPTION
## Summary

This PR completes the fork transition from `chromiumoxide` to `chaser-oxide` by updating all example imports and adding comprehensive AI assistant documentation.

**Impact**: 20 files changed (140 additions, 31 deletions)  
**Risk Level**: 🟢 Low - documentation + mechanical import updates  
**Review Time**: ~10-15 minutes

---

## What Changed

### 📝 Documentation Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | New file (+109 lines) - Claude Code guidance document |

**CLAUDE.md Contents:**
- Build and test commands (`cargo build`, `cargo test --lib`, etc.)
- Workspace structure overview (5 crates)
- Architecture documentation (ChaserPage, ChaserProfile, Page, StealthProfile)
- Key design decisions (stealth execution, profile consistency, prototype overrides)
- Usage patterns and examples
- MSRV documentation (1.75)

### 🔧 Example Updates (19 files)

All examples updated from `chromiumoxide::` → `chaser_oxide::` imports:

| Category | Files |
|----------|-------|
| Browser basics | `wiki.rs`, `wiki-async-std.rs`, `incognito.rs`, `simple-google.rs` |
| Page operations | `screenshot.rs`, `pdf.rs`, `evaluate.rs`, `add-init-script.rs` |
| Network/CDP | `block-navigation.rs`, `interception.rs`, `httpfuture.rs` |
| Advanced | `stealth_bot.rs`, `console-logs.rs`, `js-binding-listener.rs` |
| Storage | `storage-cookie.rs`, `iframe-workaround.rs` |
| Fetcher | `fetcher.rs`, `fetcher-async-std.rs` |
| Other | `evaluate-on-new-document.rs` |

### 🐛 Bug Fixes

- **`stealth_bot.rs`**: Fixed deprecated `inner()` → `raw_page()` method call

---

## Why These Changes

1. **Crate renaming completion**: The library was renamed from `chromiumoxide` to `chaser-oxide` (published on crates.io as `chaser-oxide`), but examples still used the old import paths, causing confusion and compile failures for new users.

2. **Developer experience**: Added CLAUDE.md to help AI assistants (and human developers) understand the codebase structure, build commands, and architecture quickly.

3. **API deprecation**: The `inner()` method was deprecated in favor of `raw_page()` for clarity - this fixes the last remaining usage.

---

## Type of Change

- [x] 📝 Documentation update
- [x] 🐛 Bug fix (deprecated API usage)
- [x] ♻️ Refactoring (import path updates)
- [ ] ✨ New feature
- [ ] 💥 Breaking change

---

## Testing

### Verification Commands

```bash
# All examples compile
cargo check --examples --features tokio-runtime,bytes

# Library tests pass
cargo test --lib

# Specific examples run successfully
cargo run --example stealth_bot
cargo run --example profile_demo
```

### Test Results

| Test | Status |
|------|--------|
| `cargo check --examples` | ✅ All 21 examples compile |
| `cargo test --lib` | ✅ 4/4 tests pass |
| `cargo run --example stealth_bot` | ✅ Works |
| `cargo run --example profile_demo` | ✅ Works |

---

## Breaking Changes

**None** - This PR only updates internal imports and adds documentation. No public API changes.

---

## Review Checklist

### General
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No debugging code left
- [x] No sensitive data exposed

### Documentation
- [x] CLAUDE.md is accurate and reflects current architecture
- [x] Build commands verified to work
- [x] Usage example tested

### Code Quality
- [x] All import paths are consistent (`chaser_oxide::`)
- [x] No deprecated API usage remains
- [x] Examples use current best practices

---

## Files Changed Summary

```
CLAUDE.md                            | +109 (new file)
examples/add-init-script.rs          |    1 import change
examples/block-navigation.rs         |    4 import changes
examples/console-logs.rs             |    2 import changes
examples/evaluate-on-new-document.rs |    1 import change
examples/evaluate.rs                 |    1 import change
examples/fetcher-async-std.rs        |    2 import changes
examples/fetcher.rs                  |    2 import changes
examples/httpfuture.rs               |    2 import changes
examples/iframe-workaround.rs        |    1 import change
examples/incognito.rs                |    1 import change
examples/interception.rs             |    2 import changes
examples/js-binding-listener.rs      |    1 import change
examples/pdf.rs                      |    1 import change
examples/screenshot.rs               |    2 import changes
examples/simple-google.rs            |    2 import changes
examples/stealth_bot.rs              |    1 API fix (inner→raw_page)
examples/storage-cookie.rs           |    3 import changes
examples/wiki-async-std.rs           |    1 import change
examples/wiki.rs                     |    1 import change
```

---

## Additional Notes

- The CLAUDE.md follows the standard format for Claude Code guidance files
- All changes are purely mechanical/documentation - no behavioral changes
- This PR should unblock new users who copy examples from the repository